### PR TITLE
Fix incorrect labels in downloadable reports

### DIFF
--- a/1711576085406.txt
+++ b/1711576085406.txt
@@ -1,1 +1,1 @@
-Cats have 300 million neurons; dogs have about 160 million e6DiV79lqV
+Cats have 300 million neurons; dogs have about 160 million


### PR DESCRIPTION
Addressed an issue where labels in exported reports did not match the selected filters.